### PR TITLE
Tiny Monster Trainer, fix for memory error that happens after you try to run game in the emulator from the arcade 

### DIFF
--- a/Tiny_Monster_Trainer/README.md
+++ b/Tiny_Monster_Trainer/README.md
@@ -1,6 +1,5 @@
 # Tiny_Monster_Trainer 
 A game for the Thumby  
-(I don't know what I'm doing 🥳)  
 
 Move around, fight monsters, collect monsters, train monsters.  
 

--- a/Tiny_Monster_Trainer/README.md
+++ b/Tiny_Monster_Trainer/README.md
@@ -103,7 +103,7 @@ Monster Type | Attack Name | Element Type | Damage based on Strength/Mysticism
 **Basic** | | | 
 ------- |"Poke"       |No Element Type      | Strength  
 ------- |"Hit"        |No Element Type      | Strength  
-------- |MagicHit"    |No Element Type      | Mysticism   
+------- |"MagicHit"    |No Element Type      | Mysticism   
 **Earth** |   |   |  
 ------- |"RockToss"        |Earth       | Strength  
 ------- |"Quake"           |Earth       | Mysticism  
@@ -132,7 +132,7 @@ Monster Type | Attack Name | Element Type | Damage based on Strength/Mysticism
 **Darkness**|   |   |
 ------- |"Murk"        | Darkness    | Strength  
 ------- |"Shadow"      | Darkness    | Mysticism  
-------- |'Unholy Poke" | Mystical    | Strength  
+------- |"Unholy Poke" | Mystical    | Strength  
 ------- |"Dire Ruin"   | Ethereal    | Mysticism  
 **Cute**|   |   |
 ------- |"Sing Song"   | Cute        | Strength  

--- a/Tiny_Monster_Trainer/Tiny_Monster_Trainer.py
+++ b/Tiny_Monster_Trainer/Tiny_Monster_Trainer.py
@@ -287,7 +287,7 @@ class Player:
         for x in range(0, 9):
             for y in range(0, 5):
                 if self.position[y*9+x] == 1 :
-                    thumby.display.blit(bytearray(player3_sprite), x*8 , y*8, 8, 8, -1, self.lOrR, 0)
+                    thumby.display.blit(bytearray(player3_sprite), x*8 , y*8, 8, 8, -1, 0, 0)
  
  
     def movePlayer(self, currentRoom, monster, monsterMovement):
@@ -318,7 +318,7 @@ class Player:
                 self.position[self.currentPos] = 0
                 self.currentPos = self.currentPos - 1
                 self.position[self.currentPos] = 1
-                self.lOrR = 0
+                #self.lOrR = 0
         elif(thumby.buttonR.pressed() == True):
             while(thumby.buttonR.pressed() == True): 
                 pass
@@ -327,7 +327,7 @@ class Player:
                 self.position[self.currentPos] = 0
                 self.currentPos = self.currentPos + 1
                 self.position[self.currentPos] = 1
-                self.lOrR = 1
+                #self.lOrR = 1
         if moved == 1:
             monster.moveMonster(self.currentPos, world[room], monsterMovement)
         monster.drawMonster()

--- a/Tiny_Monster_Trainer/Tiny_Monster_Trainer.py
+++ b/Tiny_Monster_Trainer/Tiny_Monster_Trainer.py
@@ -275,7 +275,7 @@ class Player:
         self.friends = []
         self.inventory = []
         self.maxHelditems = 10
-        self.lOrR = 0
+        #self.lOrR = 0
         self.currentPos = math.ceil((9 * 5) / 2)
         self.position = []
         for i in range(9 * 5):

--- a/Tiny_Monster_Trainer/Tiny_Monster_Trainer.py
+++ b/Tiny_Monster_Trainer/Tiny_Monster_Trainer.py
@@ -275,7 +275,6 @@ class Player:
         self.friends = []
         self.inventory = []
         self.maxHelditems = 10
-        #self.lOrR = 0
         self.currentPos = math.ceil((9 * 5) / 2)
         self.position = []
         for i in range(9 * 5):
@@ -287,7 +286,7 @@ class Player:
         for x in range(0, 9):
             for y in range(0, 5):
                 if self.position[y*9+x] == 1 :
-                    thumby.display.blit(bytearray(player3_sprite), x*8 , y*8, 8, 8, -1, 0, 0)
+                    thumby.display.blit(bytearray(player3_sprite), x*8 , y*8, 8, 8, -1, self.lOrR, 0)
  
  
     def movePlayer(self, currentRoom, monster, monsterMovement):
@@ -318,7 +317,7 @@ class Player:
                 self.position[self.currentPos] = 0
                 self.currentPos = self.currentPos - 1
                 self.position[self.currentPos] = 1
-                #self.lOrR = 0
+                self.lOrR = 0
         elif(thumby.buttonR.pressed() == True):
             while(thumby.buttonR.pressed() == True): 
                 pass
@@ -327,7 +326,7 @@ class Player:
                 self.position[self.currentPos] = 0
                 self.currentPos = self.currentPos + 1
                 self.position[self.currentPos] = 1
-                #self.lOrR = 1
+                self.lOrR = 1
         if moved == 1:
             monster.moveMonster(self.currentPos, world[room], monsterMovement)
         monster.drawMonster()
@@ -1738,7 +1737,7 @@ npcMonRoaming = RoamingMonster()
 monsterMovement = 0
 battle = 0
 victory = 0
-
+myGuy.lOrR = 0
 ## Pretty much the game after this point :D ##
 
 while(1):

--- a/Tiny_Monster_Trainer/arcade_description.txt
+++ b/Tiny_Monster_Trainer/arcade_description.txt
@@ -2,8 +2,7 @@ Tiny Monster Trainer
 
 Train and battle with procedurally created monsters!
 
-Please see the README.md at https://github.com/BlakeBild/Tiny_Monster_Trainer/
-for more information about the game.
+Please see the README.md for more information about the game.
 
 Author: Blake B. 
 Thanks to Mason W. & Thumby Team for References


### PR DESCRIPTION
Removed player image being able to flip depending on what way the player is moving. After making this change it allowed me to run the game from the arcade. 

Updated .txt info
Updated readme.md

(The code seemed to work when I run the code from the editor by itself, but when I opened it from the arcade I was getting a memory error? That should be fixed now *crosses fingers*)