### PR TITLE
Umby&Glow: Support for I2C display Thumbys and with ok grayscale!

### DIFF
--- a/Umby&Glow/Umby&Glow.py
+++ b/Umby&Glow/Umby&Glow.py
@@ -21,9 +21,23 @@ path.append("/Games/Umby&Glow")
 
 class _TITLE:
     from ssd1306 import SSD1306_SPI
-    from machine import Pin, SPI
-    display = SSD1306_SPI(72, 40,
-        SPI(0, sck=Pin(18), mosi=Pin(19)), dc=Pin(17), res=Pin(20), cs=Pin(16))
+    from machine import Pin, SPI, I2C
+    for i in [15, 14, 13, 12]:
+        p = Pin(i, Pin.IN, Pin.PULL_UP)
+        v = p.value()
+        p.init(p.PULL_DOWN)
+        if v == 0:
+            from ssd1306 import SSD1306_SPI
+            display = SSD1306_SPI(72, 40,
+                SPI(0, sck=Pin(18), mosi=Pin(19)), dc=Pin(17), res=Pin(20), cs=Pin(16))
+            break
+    else:
+        from ssd1306 import SSD1306_I2C
+        display = SSD1306_I2C(72, 40,
+            I2C(0, sda=Pin(16), scl=Pin(17), freq=1_500_000), res=Pin(18))
+        display.init_display()
+    import ssd1306
+    ssd1306.display = display
     @micropython.viper
     def ptr(buf) -> int:
         return int(ptr16(buf))

--- a/Umby&Glow/tape.py
+++ b/Umby&Glow/tape.py
@@ -1,5 +1,5 @@
 from array import array
-from machine import Pin, SPI
+from ssd1306 import display
 from time import sleep_ms, ticks_ms
 from utils import ihash
 
@@ -17,9 +17,6 @@ _font_index = " ABCDEFGHIJKLMNOPQRSTUVWXYZ"+"0123456789"+"!?:;'\"/><[]().,+*-"
 
 # Setup basic display access
 _FPS = const(60)
-from ssd1306 import SSD1306_SPI
-display = SSD1306_SPI(72, 40,
-    SPI(0, sck=Pin(18), mosi=Pin(19)), dc=Pin(17), res=Pin(20), cs=Pin(16))
 
 # Setup emulator, if running
 EMULATED = False
@@ -43,7 +40,7 @@ def display_update():
     t = ticks_ms()
     nwait = timer - ticks_ms()
     sleep_ms(0 if nwait <= 0 else nwait if nwait < _fwait else _fwait)
-    display.show()
+    display.write_data(_display_buffer)
     timer = ticks_ms() + _fwait
 
 def _gen_bang(blast_x, blast_y, blast_size, invert):


### PR DESCRIPTION
I2C Thumbys run Umby&Glow a little slower than SPI ones, but its still fun, and the grayscale looks reasonably good!